### PR TITLE
Return the result of `spiff_process_start` from main, add CI

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -22,3 +22,6 @@ jobs:
 
     - name: Test
       run: make tests
+
+    - name: Check fmt and clippy
+      run: make check

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -1,0 +1,24 @@
+name: Makefile CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Create dev image
+      run: make
+
+    - name: Compile
+      run: make compile
+
+    - name: Test
+      run: make tests

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,15 @@ fmt:
 clippy:
 	$(IN_DEV) cargo clippy
 
+fmt-check:
+	$(IN_DEV) cargo fmt --check
+
+clippy-check:
+	$(IN_DEV) cargo clippy -- -D warnings
+
+check: fmt-check clippy-check
+	@/bin/true
+
 sh:
 	$(IN_IDEV) /bin/bash
 
@@ -34,7 +43,7 @@ take-ownership:
 check-ownership:
 	find . ! -user $(MY_USER) ! -group $(MY_GROUP)
 
-.PHONY: dev-env tests fmt clippy \
+.PHONY: dev-env tests fmt fmt-check clippy clippy-check check \
 	sh \
 	take-ownership check-ownership \
 	compile

--- a/srt_cli/src/lib.rs
+++ b/srt_cli/src/lib.rs
@@ -20,7 +20,7 @@ struct Args {
 }
 
 extern "C" {
-    pub fn spiff_process_start(ctx: &SRTContext);
+    pub fn spiff_process_start(ctx: &SRTContext) -> i32;
 }
 
 #[cfg(not(test))]
@@ -35,11 +35,7 @@ pub extern "C" fn main() -> i32 {
 
     let ctx = SRTContext { log_level };
 
-    unsafe {
-        spiff_process_start(&ctx);
-    }
-
-    0
+    unsafe { spiff_process_start(&ctx) }
 }
 
 #[no_mangle]

--- a/srt_cli/src/lib.rs
+++ b/srt_cli/src/lib.rs
@@ -38,8 +38,11 @@ pub extern "C" fn main() -> i32 {
     unsafe { spiff_process_start(&ctx) }
 }
 
+/// # Safety
+///
+/// This function expects the caller to provide valid strings and lengths.
 #[no_mangle]
-pub extern "C" fn srt_will_run_element(
+pub unsafe extern "C" fn srt_will_run_element(
     ctx: &SRTContext,
     process_id: *const u8,
     process_id_len: usize,
@@ -60,8 +63,11 @@ pub extern "C" fn srt_will_run_element(
     }
 }
 
+/// # Safety
+///
+/// This function expects the caller to provide valid strings and lengths.
 #[no_mangle]
-pub extern "C" fn srt_did_run_element(
+pub unsafe extern "C" fn srt_did_run_element(
     ctx: &SRTContext,
     process_id: *const u8,
     process_id_len: usize,
@@ -82,8 +88,11 @@ pub extern "C" fn srt_did_run_element(
     }
 }
 
+/// # Safety
+///
+/// This function expects the caller to provide valid strings and lengths.
 #[no_mangle]
-pub extern "C" fn srt_handle_manual_task(
+pub unsafe extern "C" fn srt_handle_manual_task(
     _ctx: &SRTContext,
     element_id: *const u8,
     element_id_len: usize,
@@ -117,6 +126,5 @@ pub extern "C" fn srt_handle_manual_task(
 
 unsafe fn as_str(data: *const u8, len: usize) -> Option<&'static str> {
     data.as_ref()
-        .map(|d| from_utf8(from_raw_parts(d, len)).ok())
-        .flatten()
+        .and_then(|d| from_utf8(from_raw_parts(d, len)).ok())
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced "Makefile CI" workflow for automated building, testing, and linting on pushes and pull requests.

- **Refactor**
	- Updated CLI library functions for better error handling and safety compliance.

- **Chores**
	- Enhanced Makefile with additional targets for code quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->