### PR TITLE
Initial support for task data, clean up the C interface and logging

### DIFF
--- a/srt_cli/Cargo.toml
+++ b/srt_cli/Cargo.toml
@@ -11,3 +11,7 @@ crate-type = ["staticlib"]
 
 [dependencies]
 clap = { version = "4.4.18", features = ["derive"] }
+env_logger = "0.11.0"
+log = "0.4.20"
+serde = { version = "1.0.195", features = ["derive"] }
+serde_json = "1.0.111"

--- a/srt_cli/src/context.rs
+++ b/srt_cli/src/context.rs
@@ -1,0 +1,6 @@
+use crate::state::State;
+
+#[derive(Default)]
+pub struct Context {
+    pub task_data: State,
+}

--- a/srt_cli/src/state.rs
+++ b/srt_cli/src/state.rs
@@ -12,4 +12,3 @@ impl State {
         self.state.insert(key.to_string(), Value::from(value));
     }
 }
-}

--- a/srt_cli/src/state.rs
+++ b/srt_cli/src/state.rs
@@ -1,0 +1,16 @@
+use std::collections::HashMap;
+
+use serde_json::Value;
+
+#[derive(Default)]
+pub struct State {
+    state: HashMap<String, Value>,
+}
+
+impl State {
+    pub fn set_i64(&mut self, key: &str, value: i64) -> bool {
+        let value = Value::from(value);
+
+        self.state.insert(key.to_string(), value).is_some()
+    }
+}

--- a/srt_cli/src/state.rs
+++ b/srt_cli/src/state.rs
@@ -8,9 +8,8 @@ pub struct State {
 }
 
 impl State {
-    pub fn set_i64(&mut self, key: &str, value: i64) -> bool {
-        let value = Value::from(value);
-
-        self.state.insert(key.to_string(), value).is_some()
+    pub fn set_i64(&mut self, key: &str, value: i64) {
+        self.state.insert(key.to_string(), Value::from(value));
     }
+}
 }


### PR DESCRIPTION
Initial support for storing task data, which is used by Supreme Spoon in support of https://github.com/jbirddog/supreme-spoon/issues/21

Also cleaned up the interface exposed to C and added a logging crate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced application context management with a new `Context` structure.
	- Improved logging capabilities with a `configure_logger` function.
	- Added the ability to set integer values within the application's task data.

- **Refactor**
	- Streamlined the `main` function for better context utilization.
	- Updated several functions to improve interoperability with external C code.

- **Bug Fixes**
	- Replaced outdated constants with more appropriate ones for clarity and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->